### PR TITLE
SAXParser 에 따라서 XML attribute 의 localName을 못 얻어 오는 문제 (namespace aware 설정)

### DIFF
--- a/src/main/java/kr/dogfoot/hwpxlib/reader/common/XMLFileReader.java
+++ b/src/main/java/kr/dogfoot/hwpxlib/reader/common/XMLFileReader.java
@@ -23,6 +23,13 @@ public abstract class XMLFileReader extends DefaultHandler {
     private boolean stoppedParsing;
     private StringBuilder textBuffer;
 
+    private static boolean namespaceAware = false;
+
+    static {
+        // 초기 값은 -D 옵션에서 받아 오도록 한다.
+        namespaceAware = Boolean.parseBoolean(System.getProperty("kr.dogfoot.hwpxlib.reader.xml.namespace-aware", "false"));
+    }
+
     protected XMLFileReader(ElementReaderManager entryReaderManager) {
         this.elementReaderManager = entryReaderManager;
         currentElementReader = null;
@@ -34,6 +41,7 @@ public abstract class XMLFileReader extends DefaultHandler {
         stoppedParsing = false;
 
         SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(namespaceAware);
         SAXParser parser = factory.newSAXParser();
         parser.parse(io, this);
     }
@@ -154,5 +162,10 @@ public abstract class XMLFileReader extends DefaultHandler {
 
     public boolean stoppedParsing() {
         return stoppedParsing;
+    }
+
+    // -D 옵션을 사용하지 않는곳에서도 runtime 으로 바꿀 수 있도록 허용 한다.
+    public static void setNamespaceAware(boolean namespaceAware) {
+        XMLFileReader.namespaceAware = namespaceAware;
     }
 }

--- a/src/main/java/kr/dogfoot/hwpxlib/reader/common/XMLFileReader.java
+++ b/src/main/java/kr/dogfoot/hwpxlib/reader/common/XMLFileReader.java
@@ -26,6 +26,10 @@ public abstract class XMLFileReader extends DefaultHandler {
     private static boolean namespaceAware = false;
 
     static {
+        // XML parser 가 class com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl 면 namespace aware 를 false로 설정해도 attribute 의 localName 이 제대로 나온다.
+        // 하지만
+        // XML parser 가 class org.apache.xerces.jaxp.SAXParserImpl 이면, namespace aware 를 true 로 설정해야 attribute 의 localName 이 제대로 나온다.
+        // 그러므로 parser 에 따라서 외부에서 값을 조정할 수 있도록 하자.
         // 초기 값은 -D 옵션에서 받아 오도록 한다.
         namespaceAware = Boolean.parseBoolean(System.getProperty("kr.dogfoot.hwpxlib.reader.xml.namespace-aware", "false"));
     }


### PR DESCRIPTION
SAXParser 에 따라서 namespace aware 를 설정하지 않으면 xml attribute 의 localName 을 제대로 얻어 오지 못하는 문제가 있습니다. ( "" 을 반환함 )

이에, SAXParserFactory 생성 뒤 namespace aware 를 설정할 수 있도록 VM options 를 추가합니다.
VM options 로 "-Dkr.dogfoot.hwpxlib.reader.xml.namespace-aware=true" 값을 주면 생성되는 SAXParser 가 namespace aware 하게 동작합니다. 이로 인해 localName 이 제대로 나오게 됩니다.

namespace aware 값을 true 로 줘야만 제대로 동작하는 SAXParser 는 apache의 xerces:xercesImpl 이며, 이는 Apache Tika 를 사용할때 연동되는 XML parser 입니다.

jdk 에 포함되어 있는 기본 parser의 경우, namespace aware 가 true, false 를 구분하지 않고 잘 동작하나, 해당 코드의 영향력을 최소화 하기 위해서 namespace aware 의 값이 false  가 되도록 구현하였습니다.

startup time 에 -D 옵션을 줄 수 없는 경우를 위해 init time 혹은 runtime 에 옵션을 변경할 수 있도록 public static method 를 공개합니다.