### PR TITLE
currentElementReader 가 null 인 경우 NPE 가 발생하면서 파싱에 실패하는 문제. 

### DIFF
--- a/src/main/java/kr/dogfoot/hwpxlib/reader/common/XMLFileReader.java
+++ b/src/main/java/kr/dogfoot/hwpxlib/reader/common/XMLFileReader.java
@@ -120,16 +120,16 @@ public abstract class XMLFileReader extends DefaultHandler {
                 currentElementReader.text(textBuffer.toString());
                 textBuffer.setLength(0);
             }
-        }
 
-        currentElementReader.started(false);
-        currentElementReader.endElement();
-        elementReaderManager.release(currentElementReader);
+            currentElementReader.started(false);
+            currentElementReader.endElement();
+            elementReaderManager.release(currentElementReader);
 
-        if (currentElementReader.previousReader() == null) {
-            currentElementReader = null;
-        } else {
-            currentElementReader = currentElementReader.previousReader().switchableObjectReader() ? currentElementReader.previousReader().previousReader() : currentElementReader.previousReader();
+            if (currentElementReader.previousReader() == null) {
+                currentElementReader = null;
+            } else {
+                currentElementReader = currentElementReader.previousReader().switchableObjectReader() ? currentElementReader.previousReader().previousReader() : currentElementReader.previousReader();
+            }
         }
     }
 


### PR DESCRIPTION
구체적으로는 한컴독스에서 제공하는 기본 템플릿 파일인 "프로젝트 계획서.hwpx" 파일에서 재현되며, 구체적으로는 Contents/header.xml 에 <hh:trackchageConfig flags="56"> 부분을 처리하는 과정에서 currentElementReader 가 null 이 되면서 문제를 일으킨다.

첨부한 파일의 압축을 풀면 hwpx 파일이 나옵니다.
[프로젝트 계획서.zip](https://github.com/user-attachments/files/20320426/default.zip)

구체적인 보완은 하지 못했으나, NPE 가 발생할 수 있는 부분에 대한 처리만 하여 PR 을 보내 드립니다.